### PR TITLE
Implement Preferences class

### DIFF
--- a/src/preferences.ts
+++ b/src/preferences.ts
@@ -1,0 +1,32 @@
+import LocalStorage from 'node-localstorage';
+
+const localStorage = new LocalStorage('./localstorage/settings');
+
+export default class Preferences {
+  static get(service, property) {
+    const serviceString = localStorage.getItem(service);
+
+    if (serviceString !== null) {
+      const serviceObject = JSON.parse(serviceString);
+      return serviceObject[property];
+    }
+
+    return undefined;
+  }
+
+  static set(service, property, value) {
+    const serviceString = localStorage.getItem(service);
+    let serviceObject;
+
+    if (serviceString !== null) {
+      // Already has settings
+      serviceObject = JSON.parse(serviceString);
+    } else {
+      // New entry
+      serviceObject = {};
+    }
+
+    serviceObject[property] = value;
+    localStorage.setItem(service, JSON.stringify(serviceObject));
+  }
+}


### PR DESCRIPTION
A simple Preferences class to handle the persistent storage of preferences by services.

Getting a preference:
`Preferences.get(serviceName, propertyName)`

Setting a preference:
`Preferences.set(serviceName, propertyName, value)`

serviceName and propertyName are strings, value can be any value that can be stored in JSON.


Closes #7 