### PR TITLE
Implement automatic, proactive triggers

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node-telegram-bot-api": "^0.40.2",
     "axios": "^0.19.2",
     "bcryptjs": "^2.4.3",
+    "cron": "^1.8.2",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "express-session": "^1.17.0",

--- a/src/core/messageRouter.test.ts
+++ b/src/core/messageRouter.test.ts
@@ -21,7 +21,7 @@ function getTelegramTextMessage(text: string): ProcessedTelegramMessage {
   };
 }
 
-test('trigger works', () => {
+test('get use case by trigger phrase', () => {
   const router = new MessageRouter();
   const fooUseCase = getMockUseCase('Foo Use Case', ['foo']);
   const barUseCase = getMockUseCase('Bar Use Case', ['bar', 'mango']);
@@ -33,4 +33,19 @@ test('trigger works', () => {
   expect(router.findUseCaseByTrigger(getTelegramTextMessage('bar'))).toBe(barUseCase);
   expect(router.findUseCaseByTrigger(getTelegramTextMessage('mango'))).toBe(barUseCase);
   expect(() => router.findUseCaseByTrigger(getTelegramTextMessage('other'))).toThrow();
+});
+
+test('get use case by name', () => {
+  const router = new MessageRouter();
+  const fooUseCase = getMockUseCase('Foo Use Case', []);
+  const barUseCase = getMockUseCase('Bar Use Case', []);
+  router.registerUseCase(fooUseCase);
+  router.registerUseCase(barUseCase);
+
+  expect(fooUseCase).not.toBe(barUseCase);
+  expect(router.findUseCaseByName('Foo Use Case')).toBe(fooUseCase);
+  expect(router.findUseCaseByName('foo use case')).toBe(fooUseCase);
+  expect(router.findUseCaseByName('foousecase')).toBe(fooUseCase);
+  expect(router.findUseCaseByName('bar use case')).toBe(barUseCase);
+  expect(router.findUseCaseByName('other use case')).toBeNull();
 });

--- a/src/core/messageRouter.ts
+++ b/src/core/messageRouter.ts
@@ -24,5 +24,11 @@ class MessageRouter {
 
     throw new Error('Invalid use case');
   }
+
+  findUseCaseByName(name: string): UseCase {
+    // Remove spaces and convert to lower case
+    const unify = (t: string) => t.replace(/\s/g, '').toLowerCase();
+    return this.useCases.find((useCase) => unify(useCase.name) === unify(name)) || null;
+  }
 }
 export default MessageRouter;

--- a/src/core/messageSender.ts
+++ b/src/core/messageSender.ts
@@ -8,6 +8,7 @@ import VoiceResponse from '../classes/VoiceResponse';
 import UseCaseResponse from '../classes/UseCaseResponse';
 import TextToSpeechConnector from '../connectors/textToSpeech/textToSpeechConnector';
 import EndUseCaseResponse from '../classes/EndUseCaseResponse';
+import Preferences from './preferences';
 
 class MessageSender {
   private textToSpeech = new TextToSpeechConnector();
@@ -19,6 +20,16 @@ class MessageSender {
 
   setChatId(chatId: number) {
     this.chatId = chatId;
+    Preferences.set('general', 'chatId', chatId);
+  }
+
+  private getChatId(): number {
+    if (!this.chatId) {
+      // Read chatId from preferences if it hasn't been set in this session
+      // Relevant if proactive use case runs before any user-initiated message
+      this.chatId = Preferences.get('general', 'chatId');
+    }
+    return this.chatId;
   }
 
   async sendResponses(responses: AsyncGenerator<UseCaseResponse>): Promise<boolean> {
@@ -35,18 +46,18 @@ class MessageSender {
 
   async sendResponse(response: UseCaseResponse): Promise<Message> {
     if (response instanceof TextResponse) {
-      return this.telegramBot.sendMessage(this.chatId, response.text,
+      return this.telegramBot.sendMessage(this.getChatId(), response.text,
         { disable_web_page_preview: true });
     }
     if (response instanceof VoiceResponse) {
       const audioPath = await this.textToSpeech.synthesize(response.text);
-      return this.telegramBot.sendVoice(this.chatId, audioPath);
+      return this.telegramBot.sendVoice(this.getChatId(), audioPath);
     }
     if (response instanceof LocationResponse) {
-      return this.telegramBot.sendLocation(this.chatId, response.latitude, response.longitude);
+      return this.telegramBot.sendLocation(this.getChatId(), response.latitude, response.longitude);
     }
     if (response instanceof ImageResponse) {
-      return this.telegramBot.sendPhoto(this.chatId, response.imagePath);
+      return this.telegramBot.sendPhoto(this.getChatId(), response.imagePath);
     }
     return Promise.resolve(null);
   }

--- a/src/core/olaf.ts
+++ b/src/core/olaf.ts
@@ -10,6 +10,7 @@ import UseCase from '../interfaces/useCase';
 import ProcessedTelegramMessage from '../classes/ProcessedTelegramMessage';
 import UseCaseResponse from '../classes/UseCaseResponse';
 import TextResponse from '../classes/TextResponse';
+import Preferences from './preferences';
 
 class Olaf {
   private readonly telegramBot;
@@ -107,8 +108,10 @@ class Olaf {
       const job = new CronJob(`0 ${minute} ${hour} * * *`, async () => {
         console.log(`Running scheduled use case ${service}`);
         const useCase = this.messageRouter.findUseCaseByName(service);
-        const responses = await useCase.receiveMessage(null);
-        await this.messageSender.sendResponses(responses);
+        if (useCase) {
+          const responses = await useCase.receiveMessage(null);
+          await this.messageSender.sendResponses(responses);
+        }
       });
       this.proactiveJobs[service] = job;
       job.start();

--- a/src/core/olaf.ts
+++ b/src/core/olaf.ts
@@ -19,6 +19,7 @@ class Olaf {
   private readonly messageSender;
 
   private activeUseCase: UseCase;
+  // TODO register all proactive use cases here
   private proactiveJobs: {[key: string]: CronJob} = {
     imageoftheday: null,
   };
@@ -35,11 +36,13 @@ class Olaf {
   }
 
   start() {
+    // Start listening to Telegram messages
     this.telegramBot.on('message', (msg) => this.handleTelegramMessage(msg));
 
+    // Start proactive jobs and listening to scheduling changes
     Object.keys(this.proactiveJobs).forEach((service) => this.scheduleProactivity(service));
     Preferences.events().on('changed', (service, property) => {
-      if (property.includes('Proactive')) {
+      if (property.includes('Proactive') && service in this.proactiveJobs) {
         this.scheduleProactivity(service);
       }
     });
@@ -100,6 +103,7 @@ class Olaf {
       const hour = time[0];
       const minute = time[1];
 
+      // Schedule use case daily at the specified time
       const job = new CronJob(`0 ${minute} ${hour} * * *`, async () => {
         console.log(`Running scheduled use case ${service}`);
         const useCase = this.messageRouter.findUseCaseByName(service);

--- a/src/core/preferences.ts
+++ b/src/core/preferences.ts
@@ -1,6 +1,8 @@
 import { LocalStorage } from 'node-localstorage';
+import { EventEmitter } from 'events';
 
 const localStorage = new LocalStorage('./localstorage/settings');
+const eventEmitter = new EventEmitter();
 
 class Preferences {
   private static readonly defaults: Array<[string, string, any]> = [
@@ -44,6 +46,11 @@ class Preferences {
 
     serviceObject[property] = value;
     localStorage.setItem(service, JSON.stringify(serviceObject));
+    eventEmitter.emit('changed', service, property);
+  }
+
+  static events(): EventEmitter {
+    return eventEmitter;
   }
 }
 export default Preferences;


### PR DESCRIPTION
Use cases can be automatically triggered based on the user's preferences at a specific time of the day.

To enable proactivity for a use case, add it to the `proactiveJobs` list in `olaf.ts`, and add the preferences `<service>Proactive` and `<service>ProactiveTime`.