### PR TITLE
Add dashboard test for spotify and preferences tests

### DIFF
--- a/src/core/preferences.test.ts
+++ b/src/core/preferences.test.ts
@@ -1,0 +1,48 @@
+/* eslint-disable import/order, import/first, @typescript-eslint/no-unused-vars */
+import { LocalStorage } from 'node-localstorage';
+
+jest.mock('node-localstorage');
+
+import Preferences from './preferences';
+
+test('get preference', () => {
+  const mockLocalStorage = LocalStorage.mock.instances[0];
+  mockLocalStorage.getItem.mockReturnValueOnce('{"property": "value"}');
+
+  const pref = Preferences.get('service', 'property');
+
+  expect(pref).toBe('value');
+});
+
+test('get preference is null', () => {
+  const mockLocalStorage = LocalStorage.mock.instances[0];
+  mockLocalStorage.getItem.mockReturnValueOnce(null);
+
+  const pref = Preferences.get('service', 'property');
+
+  expect(pref).toBeNull();
+});
+
+test('set preference', () => {
+  const mockLocalStorage = LocalStorage.mock.instances[0];
+  mockLocalStorage.getItem.mockReturnValueOnce('{"property": "value"}');
+
+  Preferences.events().addListener('changed', (service, property) => {
+    expect(service).toBe('service');
+    expect(property).toBe('property');
+  });
+
+  Preferences.set('service', 'property', 'value');
+});
+
+test('set preference not set yet', () => {
+  const mockLocalStorage = LocalStorage.mock.instances[0];
+  mockLocalStorage.getItem.mockReturnValueOnce(null);
+
+  Preferences.events().addListener('changed', (service, property) => {
+    expect(service).toBe('service');
+    expect(property).toBe('property');
+  });
+
+  Preferences.set('service', 'property', 'value');
+});

--- a/src/dashboard/auth.test.ts
+++ b/src/dashboard/auth.test.ts
@@ -28,15 +28,8 @@ app.use(express.urlencoded({
 app.get('/test', Auth.isAuthenticated, (req, res) => res.sendStatus(200));
 app.get('/login', (req, res) => res.sendStatus(200));
 
-const server = app.listen(3000);
-const stopServer = () => server.close();
-
 const request = supertest(app);
 
-afterAll(() => {
-  // Stop server after testing
-  stopServer();
-});
 
 test('authenticate fails', () => {
   // @ts-ignore

--- a/src/dashboard/preferences-dashboard.test.ts
+++ b/src/dashboard/preferences-dashboard.test.ts
@@ -1,0 +1,112 @@
+/* eslint-disable import/order, import/first, @typescript-eslint/no-unused-vars */
+import * as supertest from 'supertest';
+
+import Preferences from '../core/preferences';
+import app from './preferences-dashboard';
+
+// jest.mock('express');
+jest.mock('./auth');
+jest.mock('../core/preferences');
+
+import Auth from './auth';
+
+const server = app.listen(3000);
+const stopServer = () => server.close();
+
+const request = supertest(app);
+
+afterAll(() => {
+  // Stop server after testing
+  stopServer();
+});
+
+
+test('test / not authorized', async () => {
+  // @ts-ignore
+  Auth.isAuthenticated.mockImplementationOnce((req, res, next) => res.redirect('/login'));
+
+  const res = await request.get('/');
+
+  expect(res.statusCode).toBe(302);
+});
+
+test('test /', async () => {
+  // @ts-ignore
+  Auth.isAuthenticated.mockImplementationOnce((req, res, next) => next());
+
+  const res = await request.get('/');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /data/imageoftheday', async () => {
+  // @ts-ignore
+  Preferences.set.mockImplementationOnce(() => undefined);
+
+  const res = await request.post('/data/imageoftheday').send({
+    data: JSON.stringify({
+      imageofthedayProactive: 'some_val',
+      imageofthedayProactiveTime: 'some_val',
+      imageofthedayRandom: 'some_val',
+      imageofthedayTags: 'some_val',
+    }),
+  }).type('form');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /data/dfstatus', async () => {
+  // @ts-ignore
+  Preferences.set.mockImplementationOnce(() => undefined);
+
+  const res = await request.post('/data/dfstatus').send({
+    data: JSON.stringify({
+      dfstatusProactive: 'some_val',
+      dfstatusProactiveTime: 'some_val',
+      dfstatusCalendarID: 'some_val',
+    }),
+  }).type('form');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /data/news', async () => {
+  // @ts-ignore
+  Preferences.set.mockImplementationOnce(() => undefined);
+
+  const res = await request.post('/data/news').send({
+    data: JSON.stringify({
+      newsProactive: 'some_val',
+      newsProactiveTime: 'some_val',
+      newsKeywords: 'some_val',
+    }),
+  }).type('form');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /login', async () => {
+  const res = await request.get('/login');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /login post', async () => {
+  // @ts-ignore
+  Auth.isAuthenticated.mockImplementationOnce((req, res, next) => next());
+  // @ts-ignore
+  Auth.authenticate.mockImplementationOnce(() => undefined);
+
+  const res = await request.post('/login').send({ data: { password: 'some_pass' } }).type('form');
+
+  expect(res.statusCode).toBe(302);
+});
+
+test('test /logout', async () => {
+  // @ts-ignore
+  Auth.logout.mockImplementationOnce(() => undefined);
+
+  const res = await request.get('/logout');
+
+  expect(res.statusCode).toBe(302);
+});

--- a/src/dashboard/preferences-dashboard.test.ts
+++ b/src/dashboard/preferences-dashboard.test.ts
@@ -8,9 +8,11 @@ import app from './preferences-dashboard';
 jest.mock('./auth');
 jest.mock('../core/preferences');
 
+jest.setTimeout(10000);
+
 import Auth from './auth';
 
-const server = app.listen(3000);
+const server = app.listen(3001);
 const stopServer = () => server.close();
 
 const request = supertest(app);
@@ -41,7 +43,7 @@ test('test /', async () => {
 
 test('test /data/imageoftheday', async () => {
   // @ts-ignore
-  Preferences.set.mockImplementationOnce(() => undefined);
+  Preferences.set.mockImplementation(() => undefined);
 
   const res = await request.post('/data/imageoftheday').send({
     data: JSON.stringify({
@@ -57,7 +59,7 @@ test('test /data/imageoftheday', async () => {
 
 test('test /data/dfstatus', async () => {
   // @ts-ignore
-  Preferences.set.mockImplementationOnce(() => undefined);
+  Preferences.set.mockImplementation(() => undefined);
 
   const res = await request.post('/data/dfstatus').send({
     data: JSON.stringify({
@@ -72,13 +74,26 @@ test('test /data/dfstatus', async () => {
 
 test('test /data/news', async () => {
   // @ts-ignore
-  Preferences.set.mockImplementationOnce(() => undefined);
+  Preferences.set.mockImplementation(() => undefined);
 
   const res = await request.post('/data/news').send({
     data: JSON.stringify({
       newsProactive: 'some_val',
       newsProactiveTime: 'some_val',
       newsKeywords: 'some_val',
+    }),
+  }).type('form');
+
+  expect(res.statusCode).toBe(200);
+});
+
+test('test /data/spotify', async () => {
+  // @ts-ignore
+  Preferences.set.mockImplementation(() => undefined);
+
+  const res = await request.post('/data/spotify').send({
+    data: JSON.stringify({
+      spotifyCategory: 'some_val',
     }),
   }).type('form');
 

--- a/src/dashboard/preferences-dashboard.test.ts
+++ b/src/dashboard/preferences-dashboard.test.ts
@@ -1,26 +1,13 @@
 /* eslint-disable import/order, import/first, @typescript-eslint/no-unused-vars */
 import * as supertest from 'supertest';
 
-import Preferences from '../core/preferences';
 import app from './preferences-dashboard';
+import Auth from './auth';
 
-// jest.mock('express');
 jest.mock('./auth');
 jest.mock('../core/preferences');
 
-jest.setTimeout(10000);
-
-import Auth from './auth';
-
-const server = app.listen(3001);
-const stopServer = () => server.close();
-
 const request = supertest(app);
-
-afterAll(() => {
-  // Stop server after testing
-  stopServer();
-});
 
 
 test('test / not authorized', async () => {
@@ -41,63 +28,58 @@ test('test /', async () => {
   expect(res.statusCode).toBe(200);
 });
 
-test('test /data/imageoftheday', async () => {
-  // @ts-ignore
-  Preferences.set.mockImplementation(() => undefined);
+describe('test /data/', () => {
+  beforeAll(() => {
+    // @ts-ignore
+    Auth.isAuthenticated.mockImplementation((req, res, next) => next());
+  });
 
-  const res = await request.post('/data/imageoftheday').send({
-    data: JSON.stringify({
-      imageofthedayProactive: 'some_val',
-      imageofthedayProactiveTime: 'some_val',
-      imageofthedayRandom: 'some_val',
-      imageofthedayTags: 'some_val',
-    }),
-  }).type('form');
+  test('imageoftheday', async () => {
+    const res = await request.post('/data/imageoftheday').send({
+      data: JSON.stringify({
+        imageofthedayProactive: 'some_val',
+        imageofthedayProactiveTime: 'some_val',
+        imageofthedayRandom: 'some_val',
+        imageofthedayTags: 'some_val',
+      }),
+    }).type('form');
 
-  expect(res.statusCode).toBe(200);
-});
+    expect(res.statusCode).toBe(200);
+  });
 
-test('test /data/dfstatus', async () => {
-  // @ts-ignore
-  Preferences.set.mockImplementation(() => undefined);
+  test('dfstatus', async () => {
+    const res = await request.post('/data/dfstatus').send({
+      data: JSON.stringify({
+        dfstatusProactive: 'some_val',
+        dfstatusProactiveTime: 'some_val',
+        dfstatusCalendarID: 'some_val',
+      }),
+    }).type('form');
 
-  const res = await request.post('/data/dfstatus').send({
-    data: JSON.stringify({
-      dfstatusProactive: 'some_val',
-      dfstatusProactiveTime: 'some_val',
-      dfstatusCalendarID: 'some_val',
-    }),
-  }).type('form');
+    expect(res.statusCode).toBe(200);
+  });
 
-  expect(res.statusCode).toBe(200);
-});
+  test('news', async () => {
+    const res = await request.post('/data/news').send({
+      data: JSON.stringify({
+        newsProactive: 'some_val',
+        newsProactiveTime: 'some_val',
+        newsKeywords: 'some_val',
+      }),
+    }).type('form');
 
-test('test /data/news', async () => {
-  // @ts-ignore
-  Preferences.set.mockImplementation(() => undefined);
+    expect(res.statusCode).toBe(200);
+  });
 
-  const res = await request.post('/data/news').send({
-    data: JSON.stringify({
-      newsProactive: 'some_val',
-      newsProactiveTime: 'some_val',
-      newsKeywords: 'some_val',
-    }),
-  }).type('form');
+  test('spotify', async () => {
+    const res = await request.post('/data/spotify').send({
+      data: JSON.stringify({
+        spotifyCategory: 'some_val',
+      }),
+    }).type('form');
 
-  expect(res.statusCode).toBe(200);
-});
-
-test('test /data/spotify', async () => {
-  // @ts-ignore
-  Preferences.set.mockImplementation(() => undefined);
-
-  const res = await request.post('/data/spotify').send({
-    data: JSON.stringify({
-      spotifyCategory: 'some_val',
-    }),
-  }).type('form');
-
-  expect(res.statusCode).toBe(200);
+    expect(res.statusCode).toBe(200);
+  });
 });
 
 test('test /login', async () => {

--- a/src/dashboard/preferences-dashboard.ts
+++ b/src/dashboard/preferences-dashboard.ts
@@ -138,7 +138,7 @@ app.get('/', Auth.isAuthenticated, async (req, res) => {
 });
 
 // Get dashboard data
-app.post('/data/imageoftheday', (req, res) => {
+app.post('/data/imageoftheday', Auth.isAuthenticated, (req, res) => {
   const data = JSON.parse(req.body.data);
 
   Preferences.set('imageoftheday', 'imageofthedayProactive', data.imageofthedayProactive);
@@ -168,7 +168,7 @@ app.post('/data/spotify', Auth.isAuthenticated, (req, res) => {
 });
 
 // Daily Financial Status
-app.post('/data/dfstatus', (req, res) => {
+app.post('/data/dfstatus', Auth.isAuthenticated, (req, res) => {
   const data = JSON.parse(req.body.data);
 
   Preferences.set('dfstatus', 'dfstatusProactive', data.dfstatusProactive);
@@ -178,7 +178,7 @@ app.post('/data/dfstatus', (req, res) => {
 });
 
 // News
-app.post('/data/news', (req, res) => {
+app.post('/data/news', Auth.isAuthenticated, (req, res) => {
   const data = JSON.parse(req.body.data);
 
   Preferences.set('news', 'newsProactive', data.newsProactive);


### PR DESCRIPTION
For some reason, the dashboard tests for the /data/spotify route are failing for me, allthough its code is virtually the same as for other routes. Please try it for yourself