### PR TITLE
Replaced GOOGLE_KEY with GOOGLE_TOKEN in .env

### DIFF
--- a/src/connectors/googleGeocoder/googleGeocoderConnector.test.ts
+++ b/src/connectors/googleGeocoder/googleGeocoderConnector.test.ts
@@ -2,14 +2,14 @@ import GoogleGeocoderConnector from './googleGeocoderConnector';
 
 const NodeGeocoder = require('node-geocoder');
 
-process.env.GOOGLE_KEY = null;
+process.env.GOOGLE_TOKEN = null;
 
 const geocoderOptions = {
   provider: 'google',
 
   // Optional depending on the providers
   httpAdapter: 'https', // Default
-  apiKey: process.env.GOOGLE_KEY, // for Mapquest, OpenCage, Google Premier
+  apiKey: process.env.GOOGLE_TOKEN, // for Mapquest, OpenCage, Google Premier
   formatter: null, // 'gpx', 'string', ...
 };
 

--- a/src/connectors/googleGeocoder/googleGeocoderConnector.ts
+++ b/src/connectors/googleGeocoder/googleGeocoderConnector.ts
@@ -8,7 +8,7 @@ class GoogleGeocoderConnector {
 
     // Optional depending on the providers
     httpAdapter: 'https', // Default
-    apiKey: process.env.GOOGLE_KEY, // for Mapquest, OpenCage, Google Premier
+    apiKey: process.env.GOOGLE_TOKEN, // for Mapquest, OpenCage, Google Premier
     formatter: null, // 'gpx', 'string', ...
   };
 

--- a/src/connectors/googleKnowledgeBase/googleKnowledgeBaseConnector.test.ts
+++ b/src/connectors/googleKnowledgeBase/googleKnowledgeBaseConnector.test.ts
@@ -26,7 +26,7 @@ const mockResponse = {
   ],
 };
 
-process.env.GOOGLE_KEY = null;
+process.env.GOOGLE_TOKEN = null;
 
 
 function getMockConnector(response) {

--- a/src/connectors/googleKnowledgeBase/googleKnowledgeBaseConnector.ts
+++ b/src/connectors/googleKnowledgeBase/googleKnowledgeBaseConnector.ts
@@ -5,7 +5,7 @@ class GoogleKnowledgeBaseConnector {
   private axios;
   private knowledgeOptions = {
     host: 'https://kgsearch.googleapis.com',
-    path: `v1/entities:search?key=${process.env.GOOGLE_KEY}&limit=1&types=City&types=Place`,
+    path: `v1/entities:search?key=${process.env.GOOGLE_TOKEN}&limit=1&types=City&types=Place`,
   };
 
   constructor() {

--- a/src/connectors/googleTranslator/googleTranslatorConnector.test.ts
+++ b/src/connectors/googleTranslator/googleTranslatorConnector.test.ts
@@ -18,7 +18,7 @@ const mockResponse = {
   },
 };
 
-process.env.GOOGLE_KEY = null;
+process.env.GOOGLE_TOKEN = null;
 
 
 function getMockConnector(response) {

--- a/src/connectors/googleTranslator/googleTranslatorConnector.ts
+++ b/src/connectors/googleTranslator/googleTranslatorConnector.ts
@@ -6,7 +6,7 @@ class GoogleTranslatorConnector {
 
   constructor() {
     this.axios = axios.create({
-      baseURL: `https://translation.googleapis.com/language/translate/v2?key=${process.env.GOOGLE_KEY}`,
+      baseURL: `https://translation.googleapis.com/language/translate/v2?key=${process.env.GOOGLE_TOKEN}`,
     });
   }
 

--- a/src/usecases/translator/translatorUsecase.test.ts
+++ b/src/usecases/translator/translatorUsecase.test.ts
@@ -20,7 +20,7 @@ jest.mock('../../connectors/googleKnowledgeBase/googleKnowledgeBaseConnector', (
 }));
 
 
-process.env.GOOGLE_KEY = null;
+process.env.GOOGLE_TOKEN = null;
 
 
 test('Receiving message works', async () => {

--- a/src/usecases/translator/translatorUsecase.ts
+++ b/src/usecases/translator/translatorUsecase.ts
@@ -33,7 +33,7 @@ class TranslatorUsecase implements UseCase {
 
   async* receiveMessage(message: ProcessedTelegramMessage):
   AsyncGenerator<UseCaseResponse, any, unknown> {
-    if (!('GOOGLE_KEY' in process.env)) {
+    if (!('GOOGLE_TOKEN' in process.env)) {
       throw new Error('Missing API key for Google');
     }
 


### PR DESCRIPTION
Just a quick fix for labeling inconsistencies.